### PR TITLE
Fix `import namespace` to allow dynamic import variable

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -71,6 +71,9 @@ rules:
       alphabetize:
         order: "asc"
         caseInsensitive: true
+  import/namespace:
+    - 2
+    - allowComputed: true
 settings:
   react:
     version: "detect"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@de-liker/drts",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "DE LIKER's TypeScript and React style guide",
   "main": ".eslintrc.yml",
   "repository": "https://github.com/de-liker/drts",


### PR DESCRIPTION
To allow

```ts
import * as icons from 'react-feather'
const A = icons['Activity']
```

Close #76